### PR TITLE
✨Feat: Update 공동구매 상태 필터링 수정

### DIFF
--- a/src/main/java/javachip/entity/Wish.java
+++ b/src/main/java/javachip/entity/Wish.java
@@ -20,8 +20,9 @@ import java.time.LocalDateTime;
 public class Wish {
     // PK: 찜 고유 ID
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
 
     // 찜한 사용자 (ManyToOne: 사용자 1명이 여러 찜 가능)
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/javachip/repository/GroupBuyRepository.java
+++ b/src/main/java/javachip/repository/GroupBuyRepository.java
@@ -1,10 +1,11 @@
 package javachip.repository;
 
 import javachip.entity.GroupBuy;
+import javachip.entity.GroupBuyStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface GroupBuyRepository extends JpaRepository<GroupBuy, Long> {
-    List<GroupBuy> findByProduct_Id(Long productId);
+    List<GroupBuy> findByProduct_IdAndStatus(Long productId, GroupBuyStatus status);
 }

--- a/src/main/java/javachip/service/GroupBuyService.java
+++ b/src/main/java/javachip/service/GroupBuyService.java
@@ -105,6 +105,11 @@ public class GroupBuyService {
         participantRepository.save(participant);
 
         groupBuy.setPartiCount(groupBuy.getPartiCount() + 1);
+
+        if (groupBuy.getPartiCount() >= groupBuy.getProduct().getMaxParticipants()) {
+            groupBuy.setStatus(GroupBuyStatus.COMPLETED);
+        }
+
         groupBuyRepository.save(groupBuy);
     }
 
@@ -142,7 +147,7 @@ public class GroupBuyService {
     }
 
     public List<GroupBuyListResponse> getGroupBuyListByProductId(Long productId) {
-        List<GroupBuy> groupBuys = groupBuyRepository.findByProduct_Id(productId);
+        List<GroupBuy> groupBuys = groupBuyRepository.findByProduct_IdAndStatus(productId, GroupBuyStatus.RECRUITING);
         return groupBuys.stream()
                 .map(gb -> new GroupBuyListResponse(
                         gb.getId(),


### PR DESCRIPTION
## 📌연관된 이슈 번호
32 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x]  기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝작업 내용
공동구매 상태 필터링 진행했습니다!
GroupBuyStatus 값이 RECRUTING 일 때만 공동구매 조회창에 나타나고
maxParticipants 값이랑 partiCount 값이 같아지면 값을 COMPLETED로 변경했습니다

## 💬리뷰 포인트 (선택)

## 테스트 결과 (선택)
![image](https://github.com/user-attachments/assets/569cff13-5ae6-4110-880a-84fb4a9fcebd)
상품 아이디 95번의 maxparticipants 값 4
![image](https://github.com/user-attachments/assets/789218a9-e344-44df-905a-a502b000077c)
상품 아이디 95번의 공동구매 참여자 4명일 때, 공동구매 상태 completed로 변경
