### PR TITLE
Feat: 문의 작성·조회·답변 기능 구현 완료

### DIFF
--- a/src/main/java/javachip/controller/InquiryController.java
+++ b/src/main/java/javachip/controller/InquiryController.java
@@ -1,0 +1,61 @@
+package javachip.controller;
+
+import javachip.dto.inquiry.InquiryRequest;
+import javachip.dto.inquiry.InquiryResponse;
+import javachip.service.InquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final InquiryService inquiryService;
+
+    /**
+     * 문의 등록 (구매자)
+     */
+    @PostMapping
+    public ResponseEntity<InquiryResponse> createInquiry(@RequestBody InquiryRequest request) {
+        InquiryResponse response = inquiryService.createInquiry(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 상품별 문의 목록 조회 (공개)
+     */
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<List<InquiryResponse>> getInquiriesByProduct(@PathVariable Long productId) {
+        List<InquiryResponse> responseList = inquiryService.getInquiriesByProduct(productId);
+        return ResponseEntity.ok(responseList);
+    }
+
+    /**
+     * 문의에 대한 판매자 답변 등록
+     */
+    @PatchMapping("/{inquiryId}/answer")
+    public ResponseEntity<InquiryResponse> addAnswer(
+            @PathVariable Long inquiryId,
+            @RequestParam String sellerId,
+            @RequestBody String answer
+    ) {
+        InquiryResponse response = inquiryService.addAnswer(inquiryId, sellerId, answer);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 문의 삭제 (구매자 본인만 가능)
+     */
+    @DeleteMapping("/{inquiryId}")
+    public ResponseEntity<Void> deleteInquiry(
+            @PathVariable Long inquiryId,
+            @RequestParam String userId
+    ) {
+        inquiryService.deleteInquiry(inquiryId, userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/javachip/dto/inquiry/InquiryRequest.java
+++ b/src/main/java/javachip/dto/inquiry/InquiryRequest.java
@@ -1,0 +1,26 @@
+package javachip.dto.inquiry;
+
+import javachip.entity.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryRequest {
+
+    private Long productId;
+    private String userId;
+    private InquiryCategory category;
+    private String content;
+
+    public Inquiry toEntity(Product product, Consumer consumer) {
+        return Inquiry.builder()
+                .product(product)
+                .consumer(consumer)
+                .category(category)
+                .content(content)
+                .build();
+    }
+}

--- a/src/main/java/javachip/dto/inquiry/InquiryResponse.java
+++ b/src/main/java/javachip/dto/inquiry/InquiryResponse.java
@@ -1,0 +1,36 @@
+package javachip.dto.inquiry;
+
+import javachip.entity.Inquiry;
+import javachip.entity.InquiryCategory;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryResponse {
+
+    private Long id;
+    private String userId;
+    private InquiryCategory category;
+    private String content;
+    private LocalDateTime createdAt;
+
+    private String answer;
+    private LocalDateTime answeredAt;
+
+    public static InquiryResponse fromEntity(Inquiry inquiry) {
+        return InquiryResponse.builder()
+                .id(inquiry.getId())
+                .userId(inquiry.getConsumer().getUserId())
+                .category(inquiry.getCategory())
+                .content(inquiry.getContent())
+                .createdAt(inquiry.getCreatedAt())
+                .answer(inquiry.getAnswer())
+                .answeredAt(inquiry.getAnsweredAt())
+                .build();
+    }
+}

--- a/src/main/java/javachip/entity/Inquiry.java
+++ b/src/main/java/javachip/entity/Inquiry.java
@@ -1,0 +1,50 @@
+package javachip.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Inquiry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "inquiry_seq_gen")
+    @SequenceGenerator(name = "inquiry_seq_gen", sequenceName = "INQUIRY_SEQ", allocationSize = 1)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Consumer consumer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private InquiryCategory category;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Lob
+    private String answer;
+
+    private LocalDateTime answeredAt;
+
+    /** 작성일 자동 설정 */
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/javachip/entity/InquiryCategory.java
+++ b/src/main/java/javachip/entity/InquiryCategory.java
@@ -1,0 +1,7 @@
+package javachip.entity;
+
+public enum InquiryCategory {
+    PRODUCT,     // 상품 문의
+    DELIVERY,    // 배송 문의
+    GROUP        // 공동구매 문의
+}

--- a/src/main/java/javachip/repository/InquiryRepository.java
+++ b/src/main/java/javachip/repository/InquiryRepository.java
@@ -1,0 +1,10 @@
+package javachip.repository;
+
+import javachip.entity.Inquiry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+    List<Inquiry> findByProductIdOrderByCreatedAtDesc(Long productId);
+}

--- a/src/main/java/javachip/service/InquiryService.java
+++ b/src/main/java/javachip/service/InquiryService.java
@@ -1,0 +1,17 @@
+package javachip.service;
+
+import javachip.dto.inquiry.InquiryRequest;
+import javachip.dto.inquiry.InquiryResponse;
+
+import java.util.List;
+
+public interface InquiryService {
+
+    InquiryResponse createInquiry(InquiryRequest request);
+
+    List<InquiryResponse> getInquiriesByProduct(Long productId);
+
+    InquiryResponse addAnswer(Long inquiryId, String sellerId, String answer);
+
+    void deleteInquiry(Long inquiryId, String userId);
+}

--- a/src/main/java/javachip/service/impl/InquiryServiceImpl.java
+++ b/src/main/java/javachip/service/impl/InquiryServiceImpl.java
@@ -1,0 +1,76 @@
+package javachip.service.impl;
+
+import javachip.dto.inquiry.InquiryRequest;
+import javachip.dto.inquiry.InquiryResponse;
+import javachip.entity.*;
+import javachip.repository.*;
+import javachip.service.InquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class InquiryServiceImpl implements InquiryService {
+
+    private final InquiryRepository inquiryRepository;
+    private final ProductRepository productRepository;
+    private final ConsumerRepository consumerRepository;
+
+    @Override
+    public InquiryResponse createInquiry(InquiryRequest request) {
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        Consumer consumer = consumerRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        Inquiry inquiry = request.toEntity(product, consumer);
+        Inquiry saved = inquiryRepository.save(inquiry);
+        return InquiryResponse.fromEntity(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<InquiryResponse> getInquiriesByProduct(Long productId) {
+        return inquiryRepository.findByProductIdOrderByCreatedAtDesc(productId).stream()
+                .map(InquiryResponse::fromEntity)
+                .collect(toList());
+    }
+
+    @Override
+    public InquiryResponse addAnswer(Long inquiryId, String sellerId, String answer) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("문의가 존재하지 않습니다."));
+
+        String ownerId = inquiry.getProduct().getSeller().getUserId();
+        if (!ownerId.equals(sellerId)) {
+            throw new SecurityException("본인 상품의 문의만 답변할 수 있습니다.");
+        }
+
+        inquiry.setAnswer(answer);
+        inquiry.setAnsweredAt(java.time.LocalDateTime.now());
+        return InquiryResponse.fromEntity(inquiry);
+    }
+
+    @Override
+    public void deleteInquiry(Long inquiryId, String userId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("문의가 존재하지 않습니다."));
+
+        if (!inquiry.getConsumer().getUserId().equals(userId)) {
+            throw new SecurityException("본인이 작성한 문의만 삭제할 수 있습니다.");
+        }
+
+        if (inquiry.getAnswer() != null) {
+            throw new IllegalStateException("답변이 달린 문의는 삭제할 수 없습니다.");
+        }
+
+        inquiryRepository.delete(inquiry);
+    }
+}


### PR DESCRIPTION
## 📌연관된 이슈 번호
- #55

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 버그 수정

## 📝작업 내용
- 백엔드: Inquiry 도메인, Repository, Service, Controller 구성
  - POST /api/inquiries → 문의 등록
  - GET /api/inquiries/product/{id} → 상품별 문의 목록 조회
  - PATCH /api/inquiries/{id}/answer → 판매자 답변 등록
- 프론트
  - 기존 더미 데이터 제거
  - 문의 작성 시 ENUM 변환 처리
  - 판매자 전용 답변 작성 UI 분리 (`replyVisible`, `replyInput`)
  - 카테고리 한글 출력 처리

## 💬리뷰 포인트 (선택)

## 🧪테스트 결과 (선택)
- 구매자: 문의 작성 정상 작동
- 판매자: 답변 작성/토글 정상 작동
- 문의 목록 출력 및 순서 정렬 정상
