### PR TITLE
feat: 구독 장바구니 및 구독 주문 백엔드 API 구현

### DIFF
--- a/src/main/java/javachip/config/SecurityConfig.java
+++ b/src/main/java/javachip/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package javachip.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +31,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.POST, "/api/cart/subscribe/items").permitAll()  // ✅ POST 명시
                         .requestMatchers("/signUp/**").permitAll()
                         .anyRequest().permitAll()
                 );

--- a/src/main/java/javachip/controller/SubscribeCartController.java
+++ b/src/main/java/javachip/controller/SubscribeCartController.java
@@ -1,0 +1,49 @@
+package javachip.controller;
+
+import javachip.dto.subscription.SubscribeCartItemRequest;
+import javachip.dto.subscription.SubscribeCartItemResponse;
+import javachip.service.SubscribeCartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cart/subscribe")
+public class SubscribeCartController {
+
+    private final SubscribeCartService subscribeCartService;
+
+    @PostMapping("/items")
+    public ResponseEntity<?> addToCart(@RequestHeader("userId") String userId, @RequestBody SubscribeCartItemRequest dto) {
+        System.out.println("✅ POST /items 진입 성공");
+        subscribeCartService.addItem(userId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 장바구니 목록 조회
+    @GetMapping("/{userId}")
+    public List<SubscribeCartItemResponse> getItems(@PathVariable String userId) {
+        return subscribeCartService.getItems(userId);
+    }
+
+    // 장바구니 항목 삭제
+    @DeleteMapping("/{cartItemId}")
+    public void deleteItem(@PathVariable Long cartItemId) {
+        subscribeCartService.deleteItem(cartItemId);
+    }
+
+    // 개별 항목 선택 여부 토글
+    @PostMapping("/{cartItemId}/toggle")
+    public void toggleItem(@PathVariable Long cartItemId, @RequestParam boolean selected) {
+        subscribeCartService.toggleItem(cartItemId, selected);
+    }
+
+    // 전체 선택/해제
+    @PostMapping("/toggle-all")
+    public void toggleAll(@RequestParam String userId, @RequestParam boolean selected) {
+        subscribeCartService.toggleAll(userId, selected);
+    }
+}

--- a/src/main/java/javachip/controller/SubscribeOrderController.java
+++ b/src/main/java/javachip/controller/SubscribeOrderController.java
@@ -31,8 +31,6 @@ public class SubscribeOrderController {
             @RequestHeader("userId") String userId,
             @RequestBody SubscribeOrderRequest request
     ) {
-        System.out.println("== userId: " + userId);
-        System.out.println("== request: " + request);
         subscribeOrderService.createSubscribeOrder(request, userId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/javachip/dto/subscription/SubscribeCartItemRequest.java
+++ b/src/main/java/javachip/dto/subscription/SubscribeCartItemRequest.java
@@ -1,0 +1,31 @@
+/**
+ * 구독 장바구니 항목을 추가할 때 프론트에서 보내는 데이터를 담기 위한 것
+ * */
+package javachip.dto.subscription;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SubscribeCartItemRequest {
+
+    @NotNull
+    private Long productId;
+
+    @NotNull
+    private Integer quantity;
+
+    @NotNull
+    private Integer price;
+
+    @NotNull
+    private String cycleType;         // WEEKLY or MONTHLY
+
+    @NotNull
+    private Integer cycleValue;       // 1, 2 등
+
+    @NotNull
+    private Integer deliveryPeriodInMonths;  // 구독 전체 기간 (ex: 1개월, 3개월)
+}

--- a/src/main/java/javachip/dto/subscription/SubscribeCartItemResponse.java
+++ b/src/main/java/javachip/dto/subscription/SubscribeCartItemResponse.java
@@ -1,0 +1,33 @@
+/*
+파일명: SubscribeCartItemResponse.java
+설명: 구독 장바구니 항목에 대한 응답 DTO. 프론트에서 필요한 정보만 추려서 제공.
+작성자 : 정여진
+작성일 : 2025.05.29.
+*/
+package javachip.dto.subscription;
+import javachip.entity.SubscribeCartItem;
+import lombok.Getter;
+
+@Getter
+public class SubscribeCartItemResponse {
+
+    private Long cartItemId;
+    private Long productId;
+    private String productName;
+    private int price;
+    private int quantity;
+    private String deliveryCycle;
+    private boolean isSelected;
+
+    public static SubscribeCartItemResponse fromEntity(SubscribeCartItem item) {
+        SubscribeCartItemResponse dto = new SubscribeCartItemResponse();
+        dto.cartItemId = item.getCartItemId();
+        dto.productId = item.getProduct().getId();
+        dto.productName = item.getProduct().getProductName();
+        dto.price = item.getProduct().getPrice();
+        dto.quantity = item.getQuantity();
+        dto.deliveryCycle = item.getDeliveryCycle();
+        dto.isSelected = item.isSelected();
+        return dto;
+    }
+}

--- a/src/main/java/javachip/entity/Cart.java
+++ b/src/main/java/javachip/entity/Cart.java
@@ -35,6 +35,7 @@ public class Cart {
     private Long id;
 
     @OneToOne(mappedBy = "cart", fetch = FetchType.LAZY)
+    @JoinColumn(name = "CONSUMER_ID")
     private Consumer consumer;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL)

--- a/src/main/java/javachip/entity/Consumer.java
+++ b/src/main/java/javachip/entity/Consumer.java
@@ -28,4 +28,8 @@ public class Consumer extends User {
     public void setCart(Cart cart) {
         this.cart = cart;
     }
+    public String getId() {
+        return super.getUserId(); // User 클래스에서 상속된 id
+    }
+
 }

--- a/src/main/java/javachip/entity/SubscribeCartItem.java
+++ b/src/main/java/javachip/entity/SubscribeCartItem.java
@@ -1,0 +1,34 @@
+/*
+파일명: SubscribeCartItem.java
+설명: 구독 장바구니 항목 엔티티. CartItem을 상속받아 구독 전용 필드(배송 주기 등)를 확장함.
+작성자: 정여진
+작성일: 2025.05.29.
+*/
+package javachip.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import javachip.entity.Subscription;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "SUBSCRIBE_CART_ITEM")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class SubscribeCartItem extends CartItem {
+
+    private String deliveryCycle; // ex: 1주, 2개월 등
+
+    @ManyToOne
+    @JoinColumn(name = "SUBSCRIBE_ID")
+    private Subscription subscription; // 구독 관련 엔티티
+}

--- a/src/main/java/javachip/entity/User.java
+++ b/src/main/java/javachip/entity/User.java
@@ -8,6 +8,7 @@ package javachip.entity;
 
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -93,13 +94,5 @@ public abstract class User {
 
     public void setRole(UserRole role) {
         this.role = role;
-    }
-
-    public String getNotifications() {
-        return notifications;
-    }
-
-    public void setNotifications(String notifications) {
-        this.notifications = notifications;
     }
 }

--- a/src/main/java/javachip/repository/SubscribeCartItemRepository.java
+++ b/src/main/java/javachip/repository/SubscribeCartItemRepository.java
@@ -1,0 +1,15 @@
+/*
+파일명: SubscribeCartItemRepository.java
+설명: 구독 장바구니 항목에 대한 JPA Repository.
+*/
+
+package javachip.repository;
+
+import javachip.entity.SubscribeCartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SubscribeCartItemRepository extends JpaRepository<SubscribeCartItem, Long> {
+    List<SubscribeCartItem> findByCart_Consumer_Id(String consumerId);
+}

--- a/src/main/java/javachip/service/SubscribeCartService.java
+++ b/src/main/java/javachip/service/SubscribeCartService.java
@@ -1,0 +1,14 @@
+package javachip.service;
+
+import javachip.dto.subscription.SubscribeCartItemRequest;
+import javachip.dto.subscription.SubscribeCartItemResponse;
+
+import java.util.List;
+
+public interface SubscribeCartService{
+    List<SubscribeCartItemResponse> getItems(String consumerId); // 수정됨
+    void deleteItem(Long cartItemId);
+    void toggleItem(Long cartItemId, boolean selected);
+    void toggleAll(String consumerId, boolean selected);
+    void addItem(String userId, SubscribeCartItemRequest request);
+}

--- a/src/main/java/javachip/service/impl/SubscribeCartServiceImpl.java
+++ b/src/main/java/javachip/service/impl/SubscribeCartServiceImpl.java
@@ -1,0 +1,97 @@
+/*
+파일명: SubscribeCartServiceImpl.java
+설명: 구독 장바구니 서비스 구현체.
+작성자 : 정여진
+작성일 : 2025.05.29.
+*/
+
+package javachip.service.impl;
+
+import javachip.dto.subscription.SubscribeCartItemRequest;
+import javachip.dto.subscription.SubscribeCartItemResponse;
+import javachip.entity.Cart;
+import javachip.entity.Consumer;
+import javachip.entity.Product;
+import javachip.entity.SubscribeCartItem;
+import javachip.repository.CartRepository;
+import javachip.repository.ConsumerRepository;
+import javachip.repository.ProductRepository;
+import javachip.repository.SubscribeCartItemRepository;
+import javachip.service.SubscribeCartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeCartServiceImpl implements SubscribeCartService {
+
+    private final SubscribeCartItemRepository subscribeCartItemRepository;
+    private final ConsumerRepository consumerRepository;
+    private final ProductRepository productRepository;
+    private final CartRepository cartRepository;
+
+    @Override
+    public List<SubscribeCartItemResponse> getItems(String consumerId) {
+        return subscribeCartItemRepository.findByCart_Consumer_Id(consumerId)
+                .stream()
+                .map(SubscribeCartItemResponse::fromEntity)
+                .toList();
+    }
+
+    @Override
+    public void deleteItem(Long cartItemId) {
+        subscribeCartItemRepository.deleteById(cartItemId);
+    }
+
+    @Override
+    public void toggleItem(Long cartItemId, boolean selected) {
+        SubscribeCartItem item = subscribeCartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 항목이 존재하지 않습니다."));
+        item.setSelected(selected);
+        subscribeCartItemRepository.save(item);
+    }
+
+    @Override
+    public void toggleAll(String consumerId, boolean selected) {
+        List<SubscribeCartItem> items = subscribeCartItemRepository.findByCart_Consumer_Id(consumerId);
+        for (SubscribeCartItem item : items) {
+            item.setSelected(selected);
+        }
+        subscribeCartItemRepository.saveAll(items);
+    }
+
+    @Override
+    @Transactional
+    public void addItem(String userId, SubscribeCartItemRequest request) {
+        // 1. 사용자 → 장바구니 조회
+        Consumer consumer = consumerRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Cart cart = consumer.getCart();
+        if (cart == null) {
+            cart = new Cart(consumer);
+            cartRepository.save(cart);
+            consumer.setCart(cart);
+        }
+
+        // 2. 상품 조회
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+
+        // 3. SubscribeCartItem 생성
+        SubscribeCartItem item = (SubscribeCartItem) SubscribeCartItem.builder()
+                .cart(cart)
+                .product(product)
+                .quantity(request.getQuantity())
+                //.price(request.getPrice())
+                //.deliveryCycle(request.getCycleType() + "-" + request.getCycleValue()) // 예: "WEEKLY-1"
+                //.selected(true)
+                .build();
+
+        // 4. 저장
+        subscribeCartItemRepository.save(item);
+    }
+}


### PR DESCRIPTION
## 📌연관된 이슈 번호
ex) 

## ✨PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ]  구독 (장바구니) 추가

## 📝작업 내용
- SubscribeCartController 구현 (POST /items, GET /{userId}, DELETE, toggle 포함)
- SubscribeCartService 및 SubscribeCartServiceImpl 로직 구현
- SubscribeCartItemRequest, SubscribeCartItemResponse DTO 추가
- SubscribeCartItem 엔티티 정의 (CartItem 상속, deliveryCycle 필드 추가)
- CartItem에 @SuperBuilder 적용, 형변환 오류 해결
- SecurityConfig에 POST /api/cart/subscribe/items 허용 추가
- CORS 허용 origin/headers/method 설정 추가
- SubscribeOrderController 구현 (구독 상품 즉시 주문 처리 API)


## 테스트 결과 (선택)
![image](https://github.com/user-attachments/assets/ba6af5b8-f75f-4e71-802d-196011e19f0b)
![image](https://github.com/user-attachments/assets/14d99339-9432-480b-a30f-1ebde859ee89)

